### PR TITLE
fix(exporter): local token

### DIFF
--- a/notion2md/exporter/block.py
+++ b/notion2md/exporter/block.py
@@ -16,6 +16,7 @@ class Exporter:
         output_path: str = None,
         download: bool = False,
         unzipped: bool = False,
+        notion_token: str | None = None,
     ):
         self._config = Config(
             block_id=block_id,
@@ -25,7 +26,7 @@ class Exporter:
             download=download,
             unzipped=unzipped,
         )
-        self._client = NotionClient()
+        self._client = NotionClient(token=notion_token)
         self._io = None
         self._block_convertor = None
 

--- a/notion2md/notion_api.py
+++ b/notion2md/notion_api.py
@@ -4,22 +4,10 @@ from notion_client import Client
 
 from notion2md.exceptions import MissingTokenError
 
-
-def singleton(cls):
-    instance = {}
-
-    def get_instance():
-        if cls not in instance:
-            instance[cls] = cls()
-        return instance[cls]
-
-    return get_instance
-
-
-@singleton
 class NotionClient:
-    def __init__(self):
-        token = self._get_env_variable()
+    def __init__(self, token: str | None = None):
+        if token is None:
+            token = self._get_env_variable()
         self._client = Client(auth=token)
 
     def _get_env_variable(self):


### PR DESCRIPTION
We may have many tokens, e.g. a token per user integration, and cannot rely on having just a single one in the env var.